### PR TITLE
Residual mean squares file at first and second level

### DIFF
--- a/exporter/objects/modelfitting.py
+++ b/exporter/objects/modelfitting.py
@@ -236,7 +236,8 @@ class ResidualMeanSquares(NIDMObject):
     Object representing an ResidualMeanSquares entity.
     """ 
 
-    def __init__(self, export_dir, residual_file, coordinate_system, coordinate_space_id):
+    def __init__(self, export_dir, residual_file, coordinate_system, 
+        coordinate_space_id):
         super(ResidualMeanSquares, self).__init__(export_dir)
         self.file = residual_file
         self.coord_space = CoordinateSpace(coordinate_system, 

--- a/fsl_exporter/objects/fsl_objects.py
+++ b/fsl_exporter/objects/fsl_objects.py
@@ -56,5 +56,4 @@ class Software(NIDMObject):
                             (NIDM['softwareVersion'],self.version),
                             (FSL['featVersion'], self.feat_version)))
 
-
         return self.p

--- a/test/example001/FSL_example.provn
+++ b/test/example001/FSL_example.provn
@@ -4,7 +4,7 @@ document
           prefix nidm <http://www.incf.org/ns/nidash/nidm#>
           
           entity(niiri:fsl_results_id, [prov:type='prov:Bundle', nidm:objectModel='nidm:FSLResults', nidm:version="0.2.0", prov:label="FSL Results"])
-          wasGeneratedBy(niiri:fsl_results_id, -, 2014-11-06T15:44:06.181959)
+          wasGeneratedBy(niiri:fsl_results_id, -, 2014-11-06T16:09:15.958270)
           bundle niiri:fsl_results_id
             prefix niiri <http://iri.nidash.org/>
             prefix fsl <http://www.incf.org/ns/nidash/fsl#>


### PR DESCRIPTION
Residual mean squares files is:
- 1st level: `stats/sigmasquareds.nii.gz`
- 2nd level: `stats/mean_random_effects_var1.nii.gz` + `stats/var_cope1.nii.gz` (in OLS `mean_random_effects_var1.nii.gz` exists and is equal to zero).
