### PR TITLE
Compatibility with nidmresults (PR 19)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@zip#egg=nidmresults
+ - pip install git+https://github.com/cmaumet/nidmresults.git@master#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@master#egg=nidmresults
+ - pip install git+https://github.com/cmaumet/nidmresults.git@fix_pr19#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@fix_pr19#egg=nidmresults
+ - pip install git+https://github.com/incf-nidash/nidmresults.git@master#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -392,8 +392,9 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                 # "After all thresholding, zstat1 was masked with
                 # thresh_zstat2.
                 # --> fsl_contrast_mask
-                exc_set = ExcursionSet(zFileImg, stat_num_t, visualisation,
-                                       self.coord_space, self.export_dir)
+                exc_set = ExcursionSet(
+                    zFileImg, self.coord_space, visualisation,
+                    stat_num_t, self.export_dir)
 
                 # Height Threshold
                 prob_re = r'.*set fmri\(prob_thresh\) (?P<info>\d+\.?\d+).*'
@@ -919,8 +920,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                     d['DLH'], d['volume'], d['vox_per_resels'] = \
                         np.loadtxt(smoothness_file, usecols=[1])
 
-        vol_in_units = float(d['volume'])*np.prod(
-            json.loads(self.coord_space.voxel_size))
+        vol_in_units = float(d['volume'])*np.prod(self.coord_space.voxel_size)
         vol_in_resels = float(d['volume'])/float(d['vox_per_resels'])
 
         if 'FWHMx_vx' in d:

--- a/test/export_test_battery.py
+++ b/test/export_test_battery.py
@@ -118,6 +118,12 @@ if __name__ == '__main__':
                 version_str = version.replace(".", "")
 
                 if os.path.isdir(data_dir):
+                    # Remove existent NIDM exports (if an export already exist
+                    # the program migth be stopped waiting on user output)
+                    for nidmpack in glob.glob(os.path.join(
+                            data_dir, "*.nidm.zip")):
+                        os.remove(nidmpack)
+
                     # Export to NIDM using FSL export tool
                     # fslnidm = FSL_NIDM(feat_dir=DATA_DIR_001);
                     fslnidm = FSLtoNIDMExporter(


### PR DESCRIPTION
This PR update the NIDM exporter for FSL to be compatible with the updated version of the nidmresults library implemented in https://github.com/incf-nidash/nidmresults/pull/19.