### PR TITLE
FSL Gamma HRF as individual

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@group_is_agent#egg=nidmresults
+ - pip install git+https://github.com/cmaumet/nidmresults.git@2ec66231a2eb91cc25fd187d464360059cd39daa#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 
  - pip install -r requirements.txt
- # install nidmfsl from sources
- - python setup.py install
+ - python setup.py install # install nidmfsl from sources
  - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz | tar xzvf -
  - export PATH=$PATH:`pwd`/git-lfs-1.1.2
  - cd test/data/nidmresults-examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@master#egg=nidmresults
+ - pip install git+https://github.com/cmaumet/nidmresults.git@group_is_agent#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install git+https://github.com/cmaumet/nidmresults.git@2ec66231a2eb91cc25fd187d464360059cd39daa#egg=nidmresults
+ - pip install --upgrade git+https://github.com/cmaumet/nidmresults.git@group_is_agent#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- - git remote add nidm https://github.com/cmaumet/nidm.git
+ - git remote add nidm https://github.com/incf-nidash/nidm.git
  - git fetch nidm
  - git fetch nidm --tags
- - git subtree add --prefix nidm nidm/1.3.0-rc2 --squash
+ - git subtree add --prefix nidm nidm/master --squash
  - git subtree add --prefix nidm_releases/1.0.0 nidm tags/NIDM-Results_1.0.0 --squash
  - git subtree add --prefix nidm_releases/1.1.0 nidm tags/NIDM-Results_1.1.0 --squash
  - git subtree add --prefix nidm_releases/1.2.0 nidm tags/NIDM-Results_1.2.0 --squash

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 
-# install nidmfsl from sources
+ - pip install -r requirements.txt
+ # install nidmfsl from sources
  - python setup.py install
  - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz | tar xzvf -
  - export PATH=$PATH:`pwd`/git-lfs-1.1.2
@@ -17,8 +18,6 @@ install:
  - git lfs install
  - cd ../../..
  - pip --version 
- # Install current version of nidmresults
- - pip install --upgrade git+https://github.com/incf-nidash/nidmresults.git@master#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
  - cd ../../..
  - pip --version 
  # Install current version of nidmresults
- - pip install --upgrade git+https://github.com/cmaumet/nidmresults.git@group_is_agent#egg=nidmresults
+ - pip install --upgrade git+https://github.com/incf-nidash/nidmresults.git@master#egg=nidmresults
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/bin/nidmfsl
+++ b/bin/nidmfsl
@@ -38,11 +38,13 @@ d) suffix will be appended.')
         nargs="?")
     args = parser.parse_args()
 
+    num_subjects = map(int, args.numsubjects)
+
     # Parse feat dir and export to NIDM
     fslnidm = FSLtoNIDMExporter(
         out_dirname=args.output_name, zipped=(not args.directory_output),
         version=args.version, feat_dir=args.feat_dir,
-        num_subjects=args.numsubjects, group_names=args.group_names)
+        num_subjects=num_subjects, group_names=args.group_names)
     fslnidm.parse()
     output_path = fslnidm.export()
 

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -593,7 +593,10 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             if hrf == 1:    # 1: Gaussian
                 hrf_model = NIDM_GAUSSIAN_HRF
             elif hrf == 2:  # 2 : Gamma
-                hrf_model = NIDM_GAMMA_HRF
+                if self.version['num'] in ["1.0.0", "1.1.0", "1.2.0"]:
+                    hrf_model = NIDM_GAMMA_HRF
+                else:
+                    hrf_model = FSL_FSLS_GAMMA_HRF
             elif hrf == 3:  # 3 : Double-Gamma HRF
                 hrf_model = FSL_FSLS_GAMMA_DIFFERENCE_HRF
             elif hrf == 4:  # 4 : Gamma basis functions

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -40,8 +40,8 @@ class FSLtoNIDMExporter(NIDMExporter, object):
     stored in NIDM-Results and generate a NIDM-Results export.
     """
 
-    def __init__(self, version, feat_dir, out_dirname=None, zipped=True,
-                 num_subjects=[], group_names=None):
+    def __init__(self, feat_dir, version="1.3.0-rc2", out_dirname=None,
+                 zipped=True, num_subjects=[], group_names=None):
         # Create output name if it was not set
         if not out_dirname:
                 out_dirname = os.path.basename(feat_dir)

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -69,8 +69,12 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         self.contrast_names_by_num = dict()
 
         self.num_subjects = num_subjects
+        self.groups = []
         if num_subjects:
             self.groups = zip(self.num_subjects, group_names)
+
+        self.without_group_versions = ["0.1.0", "0.2.0", "1.0.0", "1.1.0",
+                                       "1.2.0"]
 
     def parse(self):
         """
@@ -90,6 +94,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         self.first_level = (fmri_level == 1)
 
         # FIXME cope1
+
         if self.first_level:
             # stat_dir = list([os.path.join(self.feat_dir, 'stats')])
             self.analysis_dirs = list([self.feat_dir])
@@ -103,8 +108,10 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
                     self.num_subjects = 1
         else:
             if not self.num_subjects:
-                raise Exception("Group analysis with unspecified number of \
-subjects")
+                # Number of subject per groups was introduced in 1.3.0
+                if self.version['num'] not in self.without_group_versions:
+                    raise Exception("Group analysis with unspecified number of\
+ subjects")
             # If feat was called with the GUI then the analysis directory is in
             # the nested cope folder
             self.analysis_dirs = glob.glob(

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -68,7 +68,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         self.coord_space = None
         self.contrast_names_by_num = dict()
 
-        self.num_subjects = map(int, num_subjects)
+        self.num_subjects = num_subjects
         if num_subjects:
             self.groups = zip(self.num_subjects, group_names)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nidmresults==0.3.0
+nidmresults==0.3.1
 rdflib>=4.2.0
 prov>=1.0.0
 nibabel

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmfsl",
-    version="0.3.1",
+    version="0.3.2",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=("Export of FSL statistical results using NIDM\

--- a/test/export_test_battery.py
+++ b/test/export_test_battery.py
@@ -167,7 +167,8 @@ if __name__ == '__main__':
                     featdir_arg = str(data_dir)
                     numsubs_arg = ""
                     groupnmes_arg = ""
-                    if num_subjects:
+                    if num_subjects and \
+                            version not in ["1.0.0", "1.1.0", "1.2.0"]:
                         numsubs_arg = " " + " ".join(map(str, num_subjects))
                         if group_names:
                             groupnmes_arg = \


### PR DESCRIPTION
This PR updates the FSL exporter to comply with NIDM-Results 1.3.0-rc2  (cf. https://github.com/incf-nidash/nidm/pull/381) where FSL's default Gamma HRF is defined as an individual.

Additionally this PR also implements:
 -  Do not raise an error when exporting to a version earlier than 1.3.0 and the number of subjects is not provided (fixes #80).
 - Export to the latest 1.3.0-rc2 version by default (fixes #78).