### PR TITLE
Add module version, group connectivity and smoothness

### DIFF
--- a/nidmfsl/__init__.py
+++ b/nidmfsl/__init__.py
@@ -1,0 +1,3 @@
+from pkg_resources import get_distribution
+
+__version__ = get_distribution('nidmfsl').version

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -42,6 +42,13 @@ class FSLtoNIDMExporter(NIDMExporter, object):
 
     def __init__(self, feat_dir, version="1.3.0-rc2", out_dirname=None,
                  zipped=True, num_subjects=[], group_names=None):
+
+        # Absolute path to feat directory
+        feat_dir = os.path.abspath(feat_dir)
+
+        if feat_dir.endswith("/"):
+            feat_dir = feat_dir[:-1]
+
         # Create output name if it was not set
         if not out_dirname:
                 out_dirname = os.path.basename(feat_dir)

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -633,8 +633,6 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             if tempo_deriv:
                 real_ev.append(ev_name+'*temporal_derivative')
 
-            # FIXME: other hrf models (FIR...)
-
         design_matrix = DesignMatrix(design_mat_values, design_mat_image,
                                      self.export_dir, real_ev, design_type,
                                      hrf_model, drift_model)
@@ -717,12 +715,6 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
 
         rms_map = ResidualMeanSquares(self.export_dir, residuals_file,
                                       self.coord_space, temporary)
-
-        # FIXME: does not work
-        # if not self.first_level:
-        # Delete calculated rms file (a copy is now in the NIDM export)
-        # FIXME we need to add the wasDerivedFrom maps
-        #     os.remove(residuals_file)
 
         return rms_map
 
@@ -829,14 +821,6 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             info = info_found.group('info')
         return info
 
-    def _get_display_mask(self):
-        """
-        Parse FSL result directory to retreive information about display mask.
-        """
-        # FIXME this should be updated with actual contrast masking file
-        mask_file = os.path.join(self.feat_dir, 'mask.nii.gz')
-        return mask_file
-
     def _get_num_peaks(self):
         if self.feat_post_log is not None:
             num_peak_search = re.compile(r'.* --num=(?P<numpeak>\d+)+ .*')
@@ -922,13 +906,16 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             d = sm_match.groupdict()
         else:
             # smoothness was estimated without the "-V" option, recompute
-            log_file = os.path.join(self.feat_dir, 'logs', 'feat3_stats')
+            if self.first_level:
+                log_file = os.path.join(analysis_dir, 'logs', 'feat3_stats')
+
+                if not os.path.isfile(log_file):
+                    log_file = os.path.join(
+                        self.feat_dir, 'logs', 'feat3_film')
+            else:
+                log_file = os.path.join(analysis_dir, 'logs', 'feat3c_flame')
 
             if not os.path.isfile(log_file):
-                log_file = os.path.join(self.feat_dir, 'logs', 'feat3_film')
-
-            if not os.path.isfile(log_file):
-                # FIXME: not found for fsl_t_test
                 warnings.warn(
                     "Log file feat3_stats/feat3_film not found, " +
                     "noise FWHM will not be reported")

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -57,13 +57,13 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         self.feat_dir = feat_dir
 
         self.design_file = os.path.join(self.feat_dir, 'design.fsf')
-        # FIXME: maybe not always "4"?
         feat_post_log_file = os.path.join(self.feat_dir, 'logs', 'feat4_post')
-        # FIXME: this file is sometimes missing, can the connectivity info
-        # be retreive from somewhere else??
         if os.path.isfile(feat_post_log_file):
             self.feat_post_log = open(feat_post_log_file, 'r')
         else:
+            warnings.warn(
+                "Log file feat4_post not found, " +
+                "connectivity information will not be reported")
             self.feat_post_log = None
         self.coord_space = None
         self.contrast_names_by_num = dict()

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -57,7 +57,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         self.feat_dir = feat_dir
 
         self.design_file = os.path.join(self.feat_dir, 'design.fsf')
-        
+
         self.coord_space = None
         self.contrast_names_by_num = dict()
 
@@ -81,8 +81,6 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         fmri_level_re = r'.*set fmri\(level\) (?P<info>\d+).*'
         fmri_level = int(self._search_in_fsf(fmri_level_re))
         self.first_level = (fmri_level == 1)
-
-        # FIXME cope1
 
         if self.first_level:
             # stat_dir = list([os.path.join(self.feat_dir, 'stats')])
@@ -108,6 +106,8 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
 
             if not self.analysis_dirs:
                 self.analysis_dirs = list([self.feat_dir])
+
+        print self.analysis_dirs
 
             # cope_dirs
             # print cope_dirs
@@ -202,8 +202,6 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             stat_dir = os.path.join(analysis_dir, 'stats')
 
             # Degrees of freedom
-            # FIXME: check what happens when more than one contrast is
-            # performed
             dof_file = open(os.path.join(stat_dir, 'dof'), 'r')
             dof = float(dof_file.read())
 
@@ -551,7 +549,8 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
         # For first-level fMRI only
         if self.first_level:
             # Design-type: event, mixed or block
-            # FIXME: deal with other options than "custom"
+            # Deal only with the "custom" option (latest NIDM-Results version
+            # do not include design type)
             onsets_re = r'.*set fmri\(custom(?P<num>\d+)\)\s*"(?P<file>.*)".*'
             r = re.compile(onsets_re)
             onsets = [m.groupdict() for m in r.finditer(self.design_txt)]
@@ -691,7 +690,6 @@ in a first-level analysis: (numsubjects=" + ",".join(self.num_subjects)+")")
             residuals_file = os.path.join(stat_dir, 'sigmasquareds.nii.gz')
             temporary = False
         else:
-            # FIXME cope num enter here
             sigma2_group_file = os.path.join(stat_dir,
                                              'mean_random_effects_var1.nii.gz')
             sigma2_sub_file = os.path.join(stat_dir,

--- a/nidmfsl/fsl_exporter/objects/fsl_objects.py
+++ b/nidmfsl/fsl_exporter/objects/fsl_objects.py
@@ -6,6 +6,7 @@ FSL-specific classes and classes overloaded to add FSL-specific attributes.
 """
 from nidmresults.objects.generic import ExporterSoftware, NeuroimagingSoftware
 from nidmresults.objects.constants import *
+import nidmfsl
 import logging
 import uuid
 
@@ -63,8 +64,8 @@ class FSLExporterSoftware(ExporterSoftware):
 
     def __init__(self):
         self.id = NIIRI[str(uuid.uuid4())]
-        # FIXME: is there a better way to retreive current version?
-        super(FSLExporterSoftware, self).__init__(NIDM_FSL, "dev")
+        super(FSLExporterSoftware, self).__init__(
+            NIDM_FSL, nidmfsl.__version__)
 
     def export(self, nidm_version):
         """

--- a/nidmfsl/fsl_exporter/objects/fsl_objects.py
+++ b/nidmfsl/fsl_exporter/objects/fsl_objects.py
@@ -14,8 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 class FSLNeuroimagingSoftware(NeuroimagingSoftware):
-    # FIXME software should be generic and then overloaded
-
     """
     Class representing a Software entity.
     """
@@ -56,8 +54,6 @@ class FSLNeuroimagingSoftware(NeuroimagingSoftware):
 
 
 class FSLExporterSoftware(ExporterSoftware):
-    # FIXME software should be generic and then overloaded
-
     """
     Class representing a Software entity.
     """

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmfsl",
-    version="dev",
+    version="0.3.3",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=("Export of FSL statistical results using NIDM\

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmfsl",
-    version="0.3.2",
+    version="dev",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=("Export of FSL statistical results using NIDM\


### PR DESCRIPTION
This PR fixes nidmfsl 0.3.2 as follows:
 - version is now available in the module attribute `__version__` and exported as part of the NIDM-Results document
 - connectivity and smoothness information are retrieved for group analyses (fixes #47, #24) 
 - path to the FEAT directory can be defined as an absolute or a relative path (fixes #79)