### PR TITLE
Clone nidmresults-examples using HTTPS (not SSH)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - export PATH=$PATH:`pwd`/git-lfs-1.1.2
  - cd test/data/nidmresults-examples
  # Is this is not a git repo them clone nidmresults-examples
- - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git incf-nidash/nidmresults-examples .; fi
+ - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git .; fi
  - git lfs install
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git stash --include-untracked 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
   - test/data/nidmresults-examples
 python:
-  # - "2.7"
   - "3.5"
 bundler_args: --retry 20
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,20 @@ python:
 bundler_args: --retry 20
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+ # Download test data using git-lfs
+ - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz | tar xzvf -
+ - export PATH=$PATH:`pwd`/git-lfs-1.1.2
+ - cd test/data/nidmresults-examples
+ # Is this is not a git repo them clone nidmresults-examples
+ - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git incf-nidash/nidmresults-examples .; fi
+ - git lfs install
+ # Delete any previous changes (retry because lfs might download files)
+ - travis_retry git stash --include-untracked 
+ - git checkout small_fixes
+ - git pull origin small_fixes
+ # stash in case lfs failed and need to download more files
+ - travis_retry git stash --include-untracked 
+ - cd ../../..
  # Install FSL using Neurodebian
  - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
  - sudo apt-get -y update
@@ -20,19 +34,6 @@ install:
  - pip install --upgrade setuptools
  - pip install -r requirements.txt
  - python setup.py install # install nidmfsl from sources
- - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz | tar xzvf -
- - export PATH=$PATH:`pwd`/git-lfs-1.1.2
- - cd test/data/nidmresults-examples
- # Is this is not a git repo them clone nidmresults-examples
- - if ! [ -d .git ]; then git clone --depth=50 --branch=1.1.0 https://github.com/incf-nidash/nidmresults-examples.git incf-nidash/nidmresults-examples .; fi
- - git lfs install
- # Delete any previous changes (retry because lfs might download files)
- - travis_retry git stash --include-untracked 
- - git checkout small_fixes
- - git pull origin small_fixes
- # stash in case lfs failed and need to download more files
- - travis_retry git stash --include-untracked 
- - cd ../../..
  # Packages only needed for testing (others are set up in requirements.txt)
  - pip install vcrpy
  - pip install ddt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - test/data/nidmresults-examples
 python:
-  - "2.7"
+  # - "2.7"
   - "3.5"
 bundler_args: --retry 20
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - export PATH=$PATH:`pwd`/git-lfs-1.4.1
  - cd test/data/nidmresults-examples
  # Is this is not a git repo them clone nidmresults-examples
- - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git .; fi
+ - if ! [ -d .git ]; then git lfs clone https://github.com/incf-nidash/nidmresults-examples.git .; fi
  - git branch -a
  - git fetch origin
  - git branch -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
  - export PATH=$PATH:`pwd`/git-lfs-1.1.2
  - cd test/data/nidmresults-examples
  # Is this is not a git repo them clone nidmresults-examples
- - if ! [ -d .git ]; then git clone git@github.com:incf-nidash/nidmresults-examples.git .; fi
+ - if ! [ -d .git ]; then git clone --depth=50 --branch=1.1.0 https://github.com/incf-nidash/nidmresults-examples.git incf-nidash/nidmresults-examples .; fi
  - git lfs install
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git stash --include-untracked 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ bundler_args: --retry 20
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
  # Download test data using git-lfs
- - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz | tar xzvf -
- - export PATH=$PATH:`pwd`/git-lfs-1.1.2
+ - curl -sLo - https://github.com/github/git-lfs/releases/download/v1.4.1/git-lfs-linux-amd64-1.4.1.tar.gz | tar xzvf -
+ - export PATH=$PATH:`pwd`/git-lfs-1.4.1
  - cd test/data/nidmresults-examples
  # Is this is not a git repo them clone nidmresults-examples
  - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git .; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
   - test/data/nidmresults-examples
 python:
+  - "2.7"
   - "3.5"
 bundler_args: --retry 20
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
  - git branch -a
  - git fetch origin
  - git branch -a
+ - git remote -v
  - git lfs install
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git stash --include-untracked 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ install:
  - cd test/data/nidmresults-examples
  # Is this is not a git repo them clone nidmresults-examples
  - if ! [ -d .git ]; then git clone --depth=50 https://github.com/incf-nidash/nidmresults-examples.git .; fi
+ - git branch -a
+ - git fetch origin
+ - git branch -a
  - git lfs install
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git stash --include-untracked 


### PR DESCRIPTION
This PR updates the travis configuration file to clone the test data repository (https://github.com/incf-nidash/nidmresults-examples) using HTTPS rather than SSH so that the clone can be performed without public key.
