### PR TITLE
Move code specific to "fsl_full_example" to test file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
  - git lfs install
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git stash --include-untracked 
- - git checkout small_fixes
- - git pull origin small_fixes
+ - git checkout master
+ - git pull origin master
  # stash in case lfs failed and need to download more files
  - travis_retry git stash --include-untracked 
  - cd ../../..

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -614,12 +614,6 @@ class FSLtoNIDMExporter(NIDMExporter, object):
 
             missing_onset_file = list()
             for onset in onsets:
-                # This is useful for our test case (full_example) only as in
-                # real examples, this would be a full path
-                if not os.path.isabs(onset['file']):
-                    onset['file'] = os.path.join(
-                        os.path.join(self.feat_dir), onset['file'])
-
                 if os.path.isfile(onset['file']):
                     aa = np.loadtxt(onset['file'], ndmin=2)
                     max_duration = max(

--- a/test/export_test_battery.py
+++ b/test/export_test_battery.py
@@ -88,6 +88,21 @@ if __name__ == '__main__':
                             data_dir, "*.nidm.zip")):
                         os.remove(nidmpack)
 
+                    if test_name == "fsl_full_examples001":
+                    # For our test case full_examples001 we need to change path
+                    # to the onset files (stored in the feat folder) so that
+                    # the type of model (mixed, event, block) can be retreived
+                        fsf_file = os.path.join(data_dir, "design.fsf")
+                        fsf_cp = os.path.join(data_dir, "design_cp.fsf")
+                        shutil.copy(fsf_file, fsf_cp)
+                        with open(fsf_file, 'r') as fsf:
+                            design = fsf.read()
+                        with open(fsf_file, 'w') as fsf:
+                            fsf.write(
+                                design.replace(
+                                "/storage/wmsmfe/fsl_course_data/fmri_fluency",
+                                data_dir))
+
                     # Export to NIDM using FSL export tool
                     # fslnidm = FSL_NIDM(feat_dir=DATA_DIR_001);
                     featdir_arg = str(data_dir)
@@ -104,6 +119,9 @@ if __name__ == '__main__':
                         "nidmfsl " + featdir_arg + group_arg + version_arg]
                     print("\nRunning " + str(nidmfsl_cmd))
                     subprocess.check_call(nidmfsl_cmd, shell=True)
+
+                    if test_name == "fsl_full_examples001":
+                        shutil.move(fsf_cp, fsf_file)
 
                     zipped_dir = os.path.join(
                         data_dir, os.path.basename(data_dir) + ".nidm.zip")


### PR DESCRIPTION
This PR moves code specific to test case `fsl_full_example001` to the test file `export_test_battery.py` (rather than being in the main `fsl_exporter.py` function).