### PR TITLE
Compute cluster label maps using Python (rather than depending on FSL)

### DIFF
--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -441,13 +441,13 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                 if os.path.isfile(feat_post_log_file):
                     with open(feat_post_log_file, 'r') as log:
                         feat_post_log = log.read()
-                    connectivity = 26  # FSL's default
+                    connectivity = self._get_connectivity(feat_post_log)
                 else:
                     warnings.warn(
                         "Log file feat4_post not found, " +
                         "connectivity information will not be reported")
                     feat_post_log = None
-                    connectivity = self._get_connectivity(feat_post_log)
+                    connectivity = 26  # FSL's default
 
                 if connectivity == 6:
                     structure = np.array([[[0, 0, 0],

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -484,8 +484,8 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                                     str(connectivity))
 
                 # Compute connected clusters from excursion set
-                labels, num_feat = scipy.ndimage.label(excset_img.get_data(),
-                                                       structure)
+                labels, num_labels = scipy.ndimage.label(excset_img.get_data(),
+                                                         structure)
 
                 # Update labels to match FSL's table
                 # If clusters are available in voxel space
@@ -535,7 +535,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                 if cluster_vox_tab is not None:
                     # Relabel using a different set of labels to avoid conflict
                     # when doing the replacment with FSL labels
-                    labels = labels*max(num_feat, 10000)
+                    labels = labels*max(num_labels, 10000)
 
                     # Replace existing labels by FSL labels
                     for clid, _, _, _, _, x, y, z, _, _, _, _, _, _, _, _ in \

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -534,7 +534,8 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                         cluster_vox_tab[:, 5:8] = cluster_vox
 
                 if cluster_vox_tab is not None:
-                    # Relabel using new sets of labels (times 10000)
+                    # Relabel using a different set of labels to avoid conflict
+                    # when doing the replacment with FSL labels
                     labels = labels*max(num_feat, 10000)
 
                     # Replace existing labels by FSL labels

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -1074,15 +1074,15 @@ class FSLtoNIDMExporter(NIDMExporter, object):
         Parse FSL result directory to retreive peak connectivity within a
         cluster.
         """
+        # Default connectivity in FSL (26)
+        connectivity = 26
+
         if feat_post_log is not None:
             conn_re = r'cluster.* --connectivity=(?P<connectivity>\d+)+ .*'
             connectivity_search = re.compile(conn_re)
-            connectivity = int(
-                connectivity_search.search(
-                    feat_post_log).group('connectivity'))
-        else:
-            # Default connectivity in FSL (26)
-            connectivity = 26
+            conn_in_log = connectivity_search.search(feat_post_log)
+            if conn_in_log is not None:
+                connectivity = int(conn_in_log.group('connectivity'))
 
         return connectivity
 

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -527,8 +527,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                         # Transform cluster positions in mm into voxels
                         cluster_mm = cluster_mm_tab[:, 5:8]
                         excset_img = nib.load(filename)
-                        voxToWorld = excset_img.affine
-                        worldToVox = npla.inv(voxToWorld)
+                        worldToVox = npla.inv(excset_img.affine)
                         cluster_vox = apply_affine(worldToVox, cluster_mm)
                         cluster_vox_tab = cluster_mm_tab
                         cluster_vox_tab[:, 5:8] = cluster_vox

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -83,7 +83,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
             # Path to FSL library (None if unavailable)
             self.fsl_path = os.getenv('FSLDIR')
 
-        except:
+        except Exception:
             self.cleanup()
             raise
 
@@ -143,7 +143,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                         self.analyses_num[self.analysis_dirs[0]] = ""
 
             super(FSLtoNIDMExporter, self).parse()
-        except:
+        except Exception:
             self.cleanup()
             raise
 

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -429,28 +429,22 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                 zFileImg = filename
 
                 # Cluster Labels Map
-                if self.fsl_path is not None:
-                    cluster_labels_map = os.path.join(
-                        analysis_dir, '..', 'tmp_clustmap' + stat_num_t + '.nii.gz')
+                cluster_labels_map = os.path.join(
+                    analysis_dir, 'tmp_clustmap' + stat_num_t + '.nii.gz')
 
-                    excset_img = nib.load(filename)
-                    # Copy excursion set as cluster label map --> to FIX
-                    labels, unused = scipy.ndimage.label(excset_img.get_data())
-                    clusterlabels_img = nib.Nifti1Image(
-                        labels,
-                        excset_img.affine)
-                    nib.save(clusterlabels_img, cluster_labels_map)
+                excset_img = nib.load(filename)
+                # Copy excursion set as cluster label map --> to FIX
+                labels, unused = scipy.ndimage.label(excset_img.get_data())
+                clusterlabels_img = nib.Nifti1Image(
+                    labels,
+                    excset_img.affine)
+                nib.save(clusterlabels_img, cluster_labels_map)
 
-                    temporary = True
-                    clust_map = ClusterLabelsMap(
-                        cluster_labels_map, self.coord_space,
-                        suffix=stat_num_t,
-                        temporary=temporary)
-                else:
-                    warnings.warn(
-                        "'cluster' command (from FSL) not found, " +
-                        "cluster labels maps will not be exported")
-                    clust_map = None
+                temporary = True
+                clust_map = ClusterLabelsMap(
+                    cluster_labels_map, self.coord_space,
+                    suffix=stat_num_t,
+                    temporary=temporary)
 
                 # FIXME: When doing contrast masking is the excursion set
                 # stored in thresh_zstat the one after or before contrast

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -5,7 +5,12 @@ specification.
 @author: Camille Maumet <c.m.j.maumet@warwick.ac.uk>
 @copyright: University of Warwick 2013-2014
 """
-
+from nidmresults.exporter import NIDMExporter
+from nidmresults.objects.constants import *
+from nidmresults.objects.modelfitting import *
+from nidmresults.objects.contrast import *
+from nidmresults.objects.inference import *
+from nidmfsl.fsl_exporter.objects.fsl_objects import *
 
 import re
 import os
@@ -26,13 +31,6 @@ NIDM_RESULTS_SRC_DIR = os.path.join(
     os.path.dirname(NIDM_RESULTS_FSL_DIR), "nidmresults")
 if os.path.isdir(NIDM_RESULTS_SRC_DIR):
     sys.path.append(NIDM_RESULTS_SRC_DIR)
-
-from nidmresults.exporter import NIDMExporter
-from nidmresults.objects.constants import *
-from nidmresults.objects.modelfitting import *
-from nidmresults.objects.contrast import *
-from nidmresults.objects.inference import *
-from nidmfsl.fsl_exporter.objects.fsl_objects import *
 
 
 class FSLtoNIDMExporter(NIDMExporter, object):

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -525,10 +525,18 @@ class FSLtoNIDMExporter(NIDMExporter, object):
 
                     if cluster_mm_tab is not None:
                         # Transform cluster positions in mm into voxels
+                        # Read in coordinates of clusters in mm space
                         cluster_mm = cluster_mm_tab[:, 5:8]
+
+                        # Read in excursion set image header to obtain
+                        # world to voxel mapping
                         excset_img = nib.load(filename)
                         worldToVox = npla.inv(excset_img.affine)
+
+                        # Transform cluster coordinates to voxel space
                         cluster_vox = apply_affine(worldToVox, cluster_mm)
+
+                        # Record coordinates
                         cluster_vox_tab = cluster_mm_tab
                         cluster_vox_tab[:, 5:8] = cluster_vox
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 nidmresults>=2.0.0,<3.0.0
+scipy


### PR DESCRIPTION
This PR updates the codebase to rely on `scipy` rather than FSL to compute the cluster labels map:
 - This removes one call to the `cluster` command as suggested in #114 (and also the hard-coded re-thresholding at 0.01)
 - It adds `scipy` as a requirement.

@TomMaullin: can you review this PR?