### PR TITLE
Testing 5.0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   global:
     - CCACHE_COMPRESS=1
     - CASHER_TIME_OUT=500
-    - NIDM_EX_BRANCH=origin
-    - NIDM_EX_REMOTE=fsl_5.0.10
+    - NIDM_EX_BRANCH=fsl_5.0.10
+    - NIDM_EX_REMOTE=origin
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - CCACHE_COMPRESS=1
     - CASHER_TIME_OUT=500
-    - NIDM_EX_BRANCH=master
+    - NIDM_EX_BRANCH=origin
     - NIDM_EX_REMOTE=fsl_5.0.10
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - CCACHE_COMPRESS=1
     - CASHER_TIME_OUT=500
     - NIDM_EX_BRANCH=master
-    - NIDM_EX_REMOTE=origin
+    - NIDM_EX_REMOTE=fsl_5.0.10
 python:
   - "2.7"
   - "3.5"

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -1560,7 +1560,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
 
                     # Find out which columns are the coordinates.
                     x_col = self._get_column_indices(peak_file_vox, 'x')[0]
-                    print(repr(x_col))
+                    
                     # Transform coordinates from voxels to subject mm.
                     peak_tab[:, x_col:x_col+3] = apply_affine(
                         voxToWorld, peak_tab[:, x_col:x_col+3])

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -386,7 +386,7 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                 stat_map = StatisticMap(
                     location=stat_file, stat_type=stat_type,
                     contrast_name=contrast_name, dof=dof,
-                    coord_space=self.coord_space,
+                    coord_space=self.coord_space, effdof=effdof,
                     contrast_num=stat_num_idx)
 
                 # Z-Statistic Map
@@ -404,7 +404,8 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                     location=z_stat_file, stat_type='Z',
                     contrast_name=contrast_name, dof=dof,
                     coord_space=self.coord_space,
-                    contrast_num=stat_num_idx)
+                    contrast_num=stat_num_idx,
+                    effdof=effdof)
 
                 if stat_type is "T":
                     # Contrast Map

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -1560,14 +1560,19 @@ class FSLtoNIDMExporter(NIDMExporter, object):
 
                     # Find out which columns are the coordinates.
                     x_col = self._get_column_indices(peak_file_vox, 'x')[0]
-
+                    print(repr(x_col))
                     # Transform coordinates from voxels to subject mm.
                     peak_tab[:, x_col:x_col+3] = apply_affine(
                         voxToWorld, peak_tab[:, x_col:x_col+3])
 
                     # Write into a new file.
+                    if x_col==2:
+                        fmtstr = '%i %.2e %3f %3f %3f'
+                    else:
+                        fmtstr = '%i %.2e %.2E %.2e %3f %3f %3f'
                     np.savetxt(peak_file_mm, peak_tab, header=tab_hdr,
-                               comments='', fmt='%i %.2e %3f %3f %3f')
+                               comments='', fmt=fmtstr)
+
 
                     peak_mm_table = peak_tab
 


### PR DESCRIPTION
#### What does this PR do?

This is a small PR which fixing a bug discovered when testing the current exporter against data from FSL 5.0.10. The bug was that the cluster table header for F contrasts can have either 5 or 7 columns depending on the type of analysis/contrast being recorded. Previously, only the case where 5 columns were present had been tested.

#### Link to relevant issues

#### PR submission checklist
 - [x] All tests in the test suite pass
 - [x] Tick when PR is ready for review (i.e. not work-in-progress)