### PR TITLE
BF: Add suffix to search space map to deal w/ mutliple masks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ install:
  - cd ../../..
  # Avoid "html5lib requires setuptools version 18.5" error
  - pip install --upgrade setuptools
+ # install nidmresults from dev branch
+ - pip install git+https://github.com/cmaumet/nidmresults.git@fix_multi_searchspaces
  - pip install -r requirements.txt
  - python setup.py install # install nidmfsl from sources
   # Packages only needed for testing (others are set up in requirements.txt)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ install:
  - cd ../../..
  # Avoid "html5lib requires setuptools version 18.5" error
  - pip install --upgrade setuptools
- # install nidmresults from dev branch
- - pip install git+https://github.com/cmaumet/nidmresults.git@fix_multi_searchspaces
  - pip install -r requirements.txt
  - python setup.py install # install nidmfsl from sources
   # Packages only needed for testing (others are set up in requirements.txt)

--- a/nidmfsl/fsl_exporter/fsl_exporter.py
+++ b/nidmfsl/fsl_exporter/fsl_exporter.py
@@ -492,6 +492,9 @@ class FSLtoNIDMExporter(NIDMExporter, object):
             exc_sets = glob.glob(os.path.join(analysis_dir,
                                               'thresh_z*.nii.gz'))
 
+            # Search space -- a single by analysis dir shared by all exc sets
+            search_space = self._get_search_space(analysis_dir)
+
             # Find excursion sets (in a given feat directory we have one
             # excursion set per contrast)
             for filename in exc_sets:
@@ -808,9 +811,6 @@ class FSLtoNIDMExporter(NIDMExporter, object):
                             display_mask.append(DisplayMaskMap(
                                 stat_num,
                                 conmask_file, c2, self.coord_space))
-
-                # Search space
-                search_space = self._get_search_space(analysis_dir)
 
                 inference = Inference(
                     inference_act, height_thresh,
@@ -1358,7 +1358,8 @@ class FSLtoNIDMExporter(NIDMExporter, object):
             noise_fwhm_in_voxels=noise_fwhm_in_voxels,
             noise_fwhm_in_units=noise_fwhm_in_units,
             coord_space=self.coord_space,
-            noise_roughness=float(d['DLH']),)
+            noise_roughness=float(d['DLH']),
+            suffix=self.analyses_num[analysis_dir])
 
         return search_space
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nidmresults>=2.0.0,<3.0.0
+nidmresults>=2.1.0,<3.0.0
 scipy

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmfsl",
-    version="2.1.0",
+    version="2.2.0",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=("Export of FSL statistical results using NIDM\


### PR DESCRIPTION
#### What does this PR do?

This PR is companion to https://github.com/incf-nidash/nidmresults/pull/54 to fix a bug identified by @mih in incf-nidash/nidmresults-fsl#148. 

In the presence of multiple analyses directories, all search space masks were written out to the same file SearchSpaceMaskMap.nii.gz leading to a "permission error".

This PR updates the code to add a suffix to the search space file.

#### Link to relevant issues
incf-nidash/nidmresults-fsl#148
https://github.com/incf-nidash/nidmresults/pull/54

#### PR submission checklist
 - [x] All tests in the test suite pass
 - [x] Tick when PR is ready for review (i.e. not work-in-progress)